### PR TITLE
Align date format with specification

### DIFF
--- a/example_mboxwriter_test.go
+++ b/example_mboxwriter_test.go
@@ -68,14 +68,14 @@ You won't believe these prices!
 
 	// Output:
 	// File contents:
-	// 01: From bubbles@bubbletown.com Mon Jul 04 14:03:04 2022
+	// 01: From bubbles@bubbletown.com Mon Jul  4 14:03:04 2022
 	// 02: From: bubbles@bubbletown.com
 	// 03: To: mrmxpdstk@lazytown.com
 	// 04: Subject: To interpretation
 	// 05:
 	// 06: >From all of us, to all of you, be happy!
 	// 07:
-	// 08: From mrspam@corporate.corp.com Mon Jul 04 13:12:34 2022
+	// 08: From mrspam@corporate.corp.com Mon Jul  4 13:12:34 2022
 	// 09: From: mrspam@corporate.corp.com
 	// 10: To: mrmxpdstk@lazytown.com
 	// 11: Subject: Bestest offer in the universe!!11!!

--- a/from.go
+++ b/from.go
@@ -8,29 +8,19 @@ import (
 
 // TimeFormat describes the way mbox files format the 'From ' date/time field.
 // One may use this with time.Format and time.Parse functions.
-var TimeFormat string = "Mon Jan 02 15:04:05 2006"
+var TimeFormat string = "Mon Jan  2 15:04:05 2006"
 
 // ParseFrom parses a from string to its component parts.
 // It helpfully translates the date/time to a time.Time.  A mailer might use
 // this information in some way, if needed.
 func ParseFrom(from string) (addr string, date time.Time, moreinfo string, err error) {
-	splitted := strings.Split(from, " ")
-	l := len(splitted)
-	if l > 1 {
-		addr = splitted[1]
+	data, _ := strings.CutPrefix(from, "From ")
+	addr, remainder, _ := strings.Cut(data, " ")
+	if len(remainder) >= len(TimeFormat) {
+		date, err = time.Parse(TimeFormat, strings.TrimSpace(remainder[:len(TimeFormat)]))
+		moreinfo = remainder[len(TimeFormat):]
 	}
-	if l > 6 {
-		strDate := ""
-		for i := 2; i <= 6; i++ {
-			strDate = fmt.Sprintf("%s %s", strDate, splitted[i])
-		}
-		date, err = time.Parse(TimeFormat, strings.TrimSpace(strDate))
-	}
-	if l > 7 {
-		for i := 7; i < l; i++ {
-			moreinfo = fmt.Sprintf("%s %s", moreinfo, splitted[i])
-		}
-	}
+
 	return addr, date, strings.TrimSpace(moreinfo), err
 }
 

--- a/from_test.go
+++ b/from_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseFrom(t *testing.T) {
-	from := "From pi@rpi.cu Mon Jul 04 19:23:45 2022 Gads, more crap from this guy?"
+	from := "From pi@rpi.cu Mon Jul  4 19:23:45 2022 Gads, more crap from this guy?"
 	addr, date, moreinfo, err := ParseFrom(from)
 	if err != nil {
 		t.Errorf("expected success but it failed: %s", err)
@@ -15,10 +15,7 @@ func TestParseFrom(t *testing.T) {
 	if addr != expectedAddr {
 		t.Errorf("expected %s but got %s", expectedAddr, addr)
 	}
-	expectedTime, err := time.Parse(TimeFormat, "Mon Jul 04 19:23:45 2022")
-	if err != nil {
-		t.Error(err)
-	}
+	expectedTime := time.Date(2022, time.July, 4, 19, 23, 45, 0, time.UTC)
 	if expectedTime != date {
 		t.Errorf("expected %s but got %s", expectedTime.String(), date.String())
 	}
@@ -28,15 +25,24 @@ func TestParseFrom(t *testing.T) {
 	}
 }
 
+func TestParseFromNoncompliant(t *testing.T) {
+	from := "From pi@rpi.cu Mon Jul 04 19:23:45 2022"
+	_, date, _, err := ParseFrom(from)
+	if err != nil {
+		t.Errorf("expected success but it failed: %s", err)
+	}
+	expectedTime := time.Date(2022, time.July, 4, 19, 23, 45, 0, time.UTC)
+	if expectedTime != date {
+		t.Errorf("expected %s but got %s", expectedTime.String(), date.String())
+	}
+}
+
 func TestBuildFrom(t *testing.T) {
 	addr := "pi@rpi.cu"
-	date, err := time.Parse(TimeFormat, "Fri Jul 04 19:23:45 2022")
-	if err != nil {
-		t.Error(err)
-	}
+	date := time.Date(2022, time.July, 4, 19, 23, 45, 0, time.UTC)
 	moreinfo := "Gads, more crap from this guy?"
 
-	expectedFrom := "From pi@rpi.cu Mon Jul 04 19:23:45 2022 Gads, more crap from this guy?"
+	expectedFrom := "From pi@rpi.cu Mon Jul  4 19:23:45 2022 Gads, more crap from this guy?"
 
 	from := BuildFrom(addr, date, moreinfo)
 	if from != expectedFrom {


### PR DESCRIPTION
RFC 4155 defines the timestamp format for the From header line as "conformant with the syntax of the traditional UNIX 'ctime' output sans timezone". This (and the closely related function 'asctime') provide the day of month in a space-padded format, e.g. `Wed Nov  4...`. Unfortunately, many platforms implement this incorrectly by instead zero-padding the day of month, e.g. `Wed Nov 04...`.

Both formats are in common use in software that handles mbox files, but this module currently only handles the zero-padded version.

This patch rewrites ParseFrom and BuildFrom to use the space-padded format. Go's time parser will still correctly interpret the zero-padded version given a space-padded format string (but not vice versa), so the change is backwards-compatible in that any output from previous versions of BuildFrom will still be parsed correctly by ParseFrom.

Further reading: https://stackoverflow.com/q/53894148