### PR TITLE
Tolerate From line format written by Postfix

### DIFF
--- a/from.go
+++ b/from.go
@@ -16,6 +16,7 @@ var TimeFormat string = "Mon Jan  2 15:04:05 2006"
 func ParseFrom(from string) (addr string, date time.Time, moreinfo string, err error) {
 	data, _ := strings.CutPrefix(from, "From ")
 	addr, remainder, _ := strings.Cut(data, " ")
+	remainder = strings.TrimSpace(remainder)
 	if len(remainder) >= len(TimeFormat) {
 		date, err = time.Parse(TimeFormat, strings.TrimSpace(remainder[:len(TimeFormat)]))
 		moreinfo = remainder[len(TimeFormat):]

--- a/from_test.go
+++ b/from_test.go
@@ -26,7 +26,7 @@ func TestParseFrom(t *testing.T) {
 }
 
 func TestParseFromNoncompliant(t *testing.T) {
-	from := "From pi@rpi.cu Mon Jul 04 19:23:45 2022"
+	from := "From pi@rpi.cu  Mon Jul 04 19:23:45 2022"
 	_, date, _, err := ParseFrom(from)
 	if err != nil {
 		t.Errorf("expected success but it failed: %s", err)


### PR DESCRIPTION
RFC 4155 defines the From header line as having each of its components (sender address, date, optionally more information) separated by a single space character.

Unfortunately, Postfix, one of the most-widely deployed SMTP servers, writes the From line in a slightly noncompliant way, separating the address and date with *two* spaces. See the source at its GitHub mirror here:
https://github.com/vdukhovni/postfix/blob/32475272ffd1d92ecb03f60bf445ef17669205b7/postfix/src/global/mail_copy.c#L189

This patch slightly tweaks the ParseFrom function from my previous patch (#12), loosening its requirements to accept this slightly noncompliant format.